### PR TITLE
Pinned SQLAlchemy to v1.4.46

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Pin Werkzeug because it keeps breaking Flask!
 Werkzeug==2.1.2
+SQLAlchemy==1.4.46
 
 # Runtime dependencies
 Flask==2.1.2


### PR DESCRIPTION
The new version of SQLAlchemy v2.0.0 breaks `models.py`. Fixing it by pinning version 1.4.46 which is the latest 1.x version as a temporary fix until the code can be modified.