### PR TITLE
Update comment to refer to Tekton Catalog

### DIFF
--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -1,5 +1,5 @@
 #
-# This pipeline needs the following tasks from Tekton Hub
+# This pipeline needs the following tasks from Tekton Catalog
 #   - git-clone
 #   - flake8
 #


### PR DESCRIPTION
As the Tekton Hub is deprecated, we have replaced it with the Tekton Catalog.